### PR TITLE
Disable verifying token issued-at timestamp

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -260,6 +260,7 @@ class Cognito:
                 issuer=self.user_pool_url,
                 options={
                     "require": required_claims,
+                    "verify_iat": False,
                 },
             )
         except jwt.PyJWTError as err:


### PR DESCRIPTION
PyJWT v2.8.0 verifies `iat` (issued-at timestamp) by default. There are several discussions on disabling this check, since it is not within spec. [Cognito's token verification guide](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html#amazon-cognito-user-pools-using-tokens-manually-inspect) does not suggest verifying `iat`, unlike `exp`. This should not be default behavior.

Other discussions:
https://github.com/jpadilla/pyjwt/issues/814
https://github.com/jpadilla/pyjwt/issues/939