### PR TITLE
Set min Python version to 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
         "requests>=2.22.0",
     ],
     include_package_data=True,
+    python_requires=">=3.8",
     zip_safe=True,
 )


### PR DESCRIPTION
3.8 was already defined as lowest in classifiers, but this will prevent it from being installed.