### PR TITLE
Better username evaluation in get_user_obj

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -310,6 +310,13 @@ class Cognito:
         what we'd like to display to the users
         :return: dictionary of the Cognito user response
         """
+        # try to detect the username from self or the attribute list if not set
+        if username is None:
+            if attribute_list is None:
+                username = self.username
+            else:
+                username = self.username or attribute_list.get("Username")
+
         return self.user_class(
             username=username,
             attribute_list=attribute_list,


### PR DESCRIPTION
If Cognito was instantiated with an access token and without a username then get_user will return a user without a username property.

`
c = Cognito(user_pool, client_id, access_token)
u = c.get_user()
print(u.username) # prints None
`

This PR allows get_user_obj to check if username is not set and if so try to set it to self.username or the Username from attribute_list if it exists.

Order of preference for what username should be:
1) passed in username
2) self.username 
3) Username from attribute_list