### PR TITLE
Fix/add device key to auth params if set

### DIFF
--- a/pycognito/__init__.py
+++ b/pycognito/__init__.py
@@ -527,7 +527,10 @@ class Cognito:
         # only need to confirm the device if it is not already confirmed
         # if a user has saved these values and provided them, we don't need to confirm again
         # this can be determined by existence of self.device_key but no NewDeviceMetadata
-        if self.device_key is not None and "NewDeviceMetadata" in tokens["AuthenticationResult"]:
+        if (
+            self.device_key is not None
+            and "NewDeviceMetadata" in tokens["AuthenticationResult"]
+        ):
             _, self.device_password = aws.confirm_device(
                 tokens=tokens, device_name=self.device_name
             )

--- a/pycognito/utils.py
+++ b/pycognito/utils.py
@@ -46,6 +46,10 @@ class RequestsSrpAuth(requests.auth.AuthBase):
         http_header_prefix: str = "Bearer ",
         auth_token_type: TokenType = TokenType.ACCESS_TOKEN,
         boto3_client_kwargs=None,
+        device_key: str = None,
+        device_group_key: str = None,
+        device_password: str = None,
+        device_name: str = None,
     ):
         """
 
@@ -59,6 +63,10 @@ class RequestsSrpAuth(requests.auth.AuthBase):
         :param http_header_prefix: Prefix a value before the token. Defaults to "Bearer ". (Note the space)
         :param auth_token_type: Whether to populate the header with ID or ACCESS_TOKEN. Defaults to "ACCESS_TOKEN"
         :param boto3_client_kwargs: Keyword args to pass to Boto3 for client creation
+        :param device_key: Device Key for the user
+        :param device_group_key: Device Group Key for the user
+        :param device_password: Device Password for the user
+        :param device_name: Device Name for the user
         """
 
         if cognito:
@@ -70,6 +78,10 @@ class RequestsSrpAuth(requests.auth.AuthBase):
                 user_pool_region=user_pool_region,
                 username=username,
                 boto3_client_kwargs=boto3_client_kwargs,
+                device_key=device_key,
+                device_group_key=device_group_key,
+                device_password=device_password,
+                device_name=device_name,
             )
 
         self.username = username


### PR DESCRIPTION
While `AWSSRP` was updated in a previous PR to handle device authentication support, the `Cognito` class and the `RequestsSrpAuth` class were not. This left pycognito stating that it supported this while being unable to deliver on that support.

This PR fixes this:

- adds the four device metadata values to the init method of both classes
- handles adding the `DEVICE_KEY` to the auth params during authentication, if `self.device_key` is set
- handles confirming the device and setting values on `Cognito` instance when `NewDeviceMetadata` key is included in authentication response